### PR TITLE
Add more sensible options to the "Viewed Profiles Auto Clear" drop-down

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -278,6 +278,13 @@
 									<option value="1">1 Day</option>
 									<option value="2">2 Days</option>
 									<option value="3">3 Days</option>
+									<option value="7">7 Days</option>
+									<option value="15">15 Days</option>
+									<option value="30">30 Days</option>
+									<option value="90">90 Days</option>
+									<option value="180">180 Days</option>
+									<option value="365">365 Days</option>
+									<option value="99999">Never</option>
 								</select>
                             </div>
                             old.


### PR DESCRIPTION
Which profiles I've seen is important information to me, so I created more options the users can choose from if they wish to keep this information longer than 3 days. I believe these are more sensible than the default ones, but one can still use those if one wishes so.